### PR TITLE
Fix fetching latest commit in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ $(error FLASH_SIZE not configured for target)
 endif
 endif
 
-REVISION = $(shell git log -1 --format="%h")
+REVISION = $(shell git rev-parse --short HEAD)
 
 # Working directories
 ROOT		 := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
Using `git rev-parse` is compatible with PGP-signed commits, while when formatting `git log`'s output they would get mangled.