### PR TITLE
Show average cell voltage in battery page

### DIFF
--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -859,6 +859,12 @@ void showBatteryPage(void)
         i2c_OLED_set_line(rowIndex++);
         i2c_OLED_send_string(lineBuffer);
 
+        uint16_t averageCellVoltage = ((float) vbat / batteryCellCount) * 10;
+        tfp_sprintf(lineBuffer, "Avg. Cell: %d.%02dv", averageCellVoltage / 100, averageCellVoltage % 100);
+        padLineBuffer();
+        i2c_OLED_set_line(rowIndex++);
+        i2c_OLED_send_string(lineBuffer);
+
         uint8_t batteryPercentage = calculateBatteryPercentage();
         i2c_OLED_set_line(rowIndex++);
         drawHorizonalPercentageBar(SCREEN_CHARACTER_COLUMN_COUNT, batteryPercentage);


### PR DESCRIPTION
Adds a line before the first percentage bar in the battery page of the OLED screen, showing the calculated average cell voltage.