### PR TITLE
Include all values in CLI dump

### DIFF
--- a/src/main/io/serial_cli.c
+++ b/src/main/io/serial_cli.c
@@ -2586,6 +2586,7 @@ static void cliDumpTracker() {
 
 	cliPrint("\r\n\r\n# parameters\r\n");
 
+	dumpValues(MASTER_VALUE);
 	dumpValues(TRACKER_VALUE);
 
 	cliPrint("\r\n\r\n# dump finished\r\n");


### PR DESCRIPTION
Values like `align_mag` were not included in config dumps.