### PR TITLE
Read aircraft voltage from telemetry (CRSF), fixtype and voltage on OLED

### DIFF
--- a/src/main/io/display.c
+++ b/src/main/io/display.c
@@ -73,6 +73,7 @@ extern int16_t telemetry_sats;
 extern uint8_t telemetry_failed_cs;
 extern uint8_t telemetry_fixtype;
 extern uint8_t telemetry_frequency;
+extern int16_t telemetry_voltage;
 extern positionVector_t targetPosition;
 extern positionVector_t trackerPosition;
 extern bool gotFix;
@@ -660,7 +661,8 @@ void showTelemetryPage(void){
     	if(telemetry_sats>99)
     		telemetry_sats = 99;
 
-    	tfp_sprintf(lineBuffer, "Hz : %d",telemetry_frequency);
+    	tfp_sprintf(lineBuffer, "Hz : %d  V:%d.%d",telemetry_frequency, telemetry_voltage/100, telemetry_voltage%100);
+		// tfp_sprintf(lineBuffer, "Hz : %d",telemetry_frequency);
     	padLineBuffer();
     	i2c_OLED_set_line(rowIndex++);
     	i2c_OLED_send_string(lineBuffer);

--- a/src/main/tracker/crossfire.c
+++ b/src/main/tracker/crossfire.c
@@ -69,8 +69,10 @@ void processCrossfireTelemetryFrame()
     return;
   }
 
-	telemetry_fixtype = 1;
-	if (telemetry_sats < 5) && (telemetry_sats > 0) {
+	if (telemetry_sats == 0) { 
+	telemetry_fixtype = 0; 
+	}
+	else if (telemetry_sats < 5 && telemetry_sats > 0) {
 	   telemetry_fixtype = 2;
 	   }
 	else {

--- a/src/main/tracker/crossfire.c
+++ b/src/main/tracker/crossfire.c
@@ -37,7 +37,7 @@ uint8_t telemetryRxBuffer[TELEMETRY_RX_PACKET_SIZE];   // Receive buffer. 9 byte
 uint8_t telemetryRxBufferCount = 0;
 uint8_t posCount = 0;
 
-//Voltage sensor = voltage
+//VFAS sensor = voltage
 int16_t telemetry_voltage;
 
 bool checkCrossfireTelemetryFrameCRC()
@@ -69,27 +69,18 @@ void processCrossfireTelemetryFrame()
     return;
   }
 
-
 	telemetry_fixtype = 1;
-    if (telemetry_sats < 5)
-        telemetry_fixtype = 2;
-    else
-        telemetry_fixtype = 3;
-        
+	if (telemetry_sats < 5) {
+	   telemetry_fixtype = 2;
+	   }
+	else {
+	   telemetry_fixtype = 3;
+	   } 
         
   uint8_t id = telemetryRxBuffer[2];
   int32_t value;
   switch(id) {
     case GPS_ID:
-// 0x02 GPS
-// Payload:
-// int32_t     Latitude ( degree / 10.000.000 )
-// int32_t     Longitude (degree / 10.000.000 )
-// uint16_t    Groundspeed ( km/h / 10 )
-// uint16_t    GPS heading ( degree / 100 )
-// uint16      Altitude ( meter ­1000m offset )
-// uint8_t     Satellites in use ( counter )
-
       if (getCrossfireTelemetryValue(4, 3, &value)){
         telemetry_lat = value / 10;
         if(posCount == 0) posCount++;
@@ -110,15 +101,8 @@ void processCrossfireTelemetryFrame()
         telemetry_sats = (uint16_t) value;
       break;
       case BAT_ID:
-// 0x08 Battery sensor
-// Payload:
-// uint16_t    Voltage ( mV * 100 )
-// uint16_t    Current ( mA * 100 )
-// uint24_t    Capacity ( mAh )
-// uint8_t     Battery remaining ( percent )
-
-      if (getCrossfireTelemetryValue(1, 3, &value))
-        telemetry_voltage = (uint16_t) value;
+      if (getCrossfireTelemetryValue(2, 3, &value))
+        telemetry_voltage = (uint16_t) (value * 10);
       break;
     }
   if(posCount == 2 ) {

--- a/src/main/tracker/crossfire.c
+++ b/src/main/tracker/crossfire.c
@@ -70,7 +70,7 @@ void processCrossfireTelemetryFrame()
   }
 
 	telemetry_fixtype = 1;
-	if (telemetry_sats < 5) {
+	if (telemetry_sats < 5) && (telemetry_sats > 0) {
 	   telemetry_fixtype = 2;
 	   }
 	else {


### PR DESCRIPTION
• Reads battery sensor from CRSF telemetry
• Voltage is displayer on the OLED
• Added telemetry_fixtype

![IMG_20200622_162314_resized_20200622_043452181](https://user-images.githubusercontent.com/11768024/85300028-59a86380-b4a6-11ea-8de0-ee722b24a389.jpg)
