### PR TITLE
Fix for spontaneous reboots/cli mode during unstable BT connection 

### DIFF
--- a/src/main/tracker/main.c
+++ b/src/main/tracker/main.c
@@ -791,7 +791,9 @@ void updateReadTelemetry(void){
 	if (serialRxBytesWaiting(trackerSerial)>1){
 		uint8_t c = serialRead(trackerSerial);
 
+		if (homeSet != true) {
 		evaluateOtherData(trackerSerial,c);
+		}
 
 		LED0_ON;
 


### PR DESCRIPTION
Fixes #94
Ignores other serial data **WHILE** HOMEPOINT is set - reboots will occasionally still happen but not anymore during tracking

Notes:
• FC will not connect to configurator in this state anymore - HOME needs to be reset for that! 
• Sim is working anytime. 