### PR TITLE
docs: fix broken link in GPS configuration document

### DIFF
--- a/docs/configuration-compass.md
+++ b/docs/configuration-compass.md
@@ -71,7 +71,7 @@ CW270FLIP
 
 ### Magnetic Declination
 
-To change magnetic declination you have to set correct declination of your spesific location, which can be found [here](www.magnetic-declination.com).
+To change magnetic declination you have to set correct declination of your spesific location, which can be found [here](http://www.magnetic-declination.com).
 
 If your magnetic declination readings are e.g. +3° 34' , the value entered in the u360gts configurator is 334. For west declination, use a minus value, e.g. for 1° 32' W, the value entered in the u360gts configurator is -132. In all cases (both CLI and GUI), the least significant digits are minutes, not decimal degrees.
 

--- a/docs/configuration-gps.md
+++ b/docs/configuration-gps.md
@@ -11,7 +11,6 @@ Two GPS protocols are supported. NMEA text and UBLOX binary.
 Enable the GPS as follows:
 
 1. Connect your GPS to the serial port for GPS.
-1. [Configure a serial port to use for GPS.](configuration-serial.md)
 1. Enable the `feature GPS`
 1. Set your GPS baud rate
 1. set the `GPS provider`
@@ -19,7 +18,7 @@ Enable the GPS as follows:
 
 Note:  GPS packet loss has been observed at 115200.  Try lower baud rate if you experience this.
 
-For the connections step check the [wiring documentation](hardware-wiring-schematics.md) for pins and port numbers.
+For the connections step check the [wiring documentation](install-wiring-schematics.md) for pins and port numbers.
 
 ### GPS Provider
 

--- a/docs/configuration-gps.md
+++ b/docs/configuration-gps.md
@@ -10,11 +10,12 @@ Two GPS protocols are supported. NMEA text and UBLOX binary.
 
 Enable the GPS as follows:
 
-1. Connect your GPS to the serial port for GPS.
-1. Enable the `feature GPS`
-1. Set your GPS baud rate
-1. set the `GPS provider`
-1. save and reboot.
+1. Connect your GPS to the desired serial port for GPS.
+2. [Configure serial port to be used by GPS.](configuration-serial.md)
+3. Enable the `feature GPS`
+4. Set your GPS baud rate
+5. set the `GPS provider`
+6. save and reboot.
 
 Note:  GPS packet loss has been observed at 115200.  Try lower baud rate if you experience this.
 

--- a/docs/hardware-list-of-components.md
+++ b/docs/hardware-list-of-components.md
@@ -2,7 +2,7 @@
 
 **Please, take into account that the frame is still a work in progress and this list might change**.
 
-This list of components is suitable for the [u360gts official 3d printted frame](https://github.com/raul-ortega/u360gts/blob/master/wiki/hardware-frame.md).
+This list of components is suitable for the [u360gts official 3d printted frame](hardware-frame.md).
 
 **Note:** Other alternatives to this list are possible for other frames, please contact the community of users to get more information. 
 


### PR DESCRIPTION
There is no file'configuration-serial.md'. Also there's no
way to configure a serial port for GPS other than setting the
buad rate and provider. Just delete that line.

The link to the 'wiring documentation' has also been fixed.

Signed-off-by: Stefan Naewe <stefan.naewe@gmail.com>