### PR TITLE
max speed filter m/s setting, when exceeded causes tracking to stop u…

### DIFF
--- a/src/main/tracker/main.c
+++ b/src/main/tracker/main.c
@@ -906,7 +906,7 @@ void updateTargetPosition(void){
 				currentDistance = distance_between(targetLast.lat / TELEMETRY_LATLON_DIVIDER_F,targetLast.lon / TELEMETRY_LATLON_DIVIDER_F,targetPosition.lat / TELEMETRY_LATLON_DIVIDER_F,targetPosition.lon / TELEMETRY_LATLON_DIVIDER_F);
 				currentTimeMillis = millis();
 				currentSpeed = epsVectorSpeed(targetLast.time,currentTimeMillis,currentDistance);
-				if(masterConfig.max_speed_filter == 0 || targetCurrent.speed < masterConfig.max_speed_filter){
+				if(masterConfig.max_speed_filter == 0 || currentSpeed < masterConfig.max_speed_filter){
 					epsVectorLoad(&targetCurrent,targetPosition.lat,targetPosition.lon,currentDistance,targetLast.time,currentTimeMillis);//epsVectorSpeed(targetLast.time,currentTimeMillis,currentDistance);
 					if(homeSet) {
 						if(feature(FEATURE_EPS)) {


### PR DESCRIPTION
## restore max_speed_filter fix lost in forced merge  
Use currentSpeed (freshly computed from current distance/time) instead of targetCurrent.speed (stale EPS vector value) in the max_speed_filter condition. Previously, exceeding the threshold permanently stalled epsVectorLoad, freezing the tracker until reboot.

Bug report and fix by @AlexC176 (https://github.com/AlexC176) in issue #121 (https://github.com/raul-ortega/u360gts/issues/121). This fix was present in RC1-11.1.0 but was dropped from the development branch after a forced merge from master. Re-applied via cherry-pick from commit 82f7264 (https://github.com/raul-ortega/u360gts/commit/82f72644537d6300a97a023d7f0af512dd01165e).

Closes #121 (https://github.com/raul-ortega/u360gts/issues/121).